### PR TITLE
:sparkles: [Exports] labels in workshop and permanence exports

### DIFF
--- a/src/Controller/Admin/PermanenceCrudController.php
+++ b/src/Controller/Admin/PermanenceCrudController.php
@@ -37,6 +37,7 @@ class PermanenceCrudController extends ExportableCrudController
         'createdAt',
         'updatedAt',
         'author',
+        'center.tags',
         'center',
         'place',
     ];

--- a/src/Controller/Admin/WorkshopCrudController.php
+++ b/src/Controller/Admin/WorkshopCrudController.php
@@ -41,6 +41,7 @@ class WorkshopCrudController extends ExportableCrudController
         'nbCreatedEvents',
         'nbCreatedContacts',
         'nbCreatedNotes',
+        'center.tags',
         'center',
         'author',
         'createdAt',

--- a/translations/messages.fr.yaml
+++ b/translations/messages.fr.yaml
@@ -83,5 +83,6 @@ noGenderCount: Nb autres
 place: Lieu
 proNotes: Remarques concernant les bénéficiaires
 reconnectNotes: Remarques concernant Reconnect
+tags: Labels
 unfilled: Non renseigné
 updatedAt: Date de mise à jour


### PR DESCRIPTION
[Ticket 1](https://trello.com/c/e1eRR0cN/3651-31-en-tant-quadmin-dans-le-ficher-dexport-des-accompagnements-num%C3%A9riques-jai-une-colonne-label) et [Ticket 2](https://trello.com/c/gDwMRumR/3650-1-en-tant-quadmin-dans-le-ficher-dexport-des-permanences-cfn-jai-une-colonne-label)